### PR TITLE
Adds a loading indicator manager so the application's network activit…

### DIFF
--- a/ThunderTable.xcodeproj/project.pbxproj
+++ b/ThunderTable.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		493EED411BB4086D004FB9A3 /* TSCStoryboardRow.m in Sources */ = {isa = PBXBuildFile; fileRef = 493EED3F1BB4086D004FB9A3 /* TSCStoryboardRow.m */; };
 		B140B0101C44023E00F108CE /* TSCDatePickerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B140B00F1C44023E00F108CE /* TSCDatePickerView.xib */; };
 		B140B0121C44034200F108CE /* TSCDatePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B140B0111C44034100F108CE /* TSCDatePickerView.swift */; };
+		B15560FE1CBE49B400834825 /* ApplicationLoadingIndicatorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B15560FD1CBE49B400834825 /* ApplicationLoadingIndicatorManager.swift */; };
 		B1A695521B96F95D001EB098 /* TSCTheme.m in Sources */ = {isa = PBXBuildFile; fileRef = B1A695511B96F95D001EB098 /* TSCTheme.m */; };
 		B1A695591B96FF6F001EB098 /* TSCPickerComponent.h in Headers */ = {isa = PBXBuildFile; fileRef = B1A695531B96FF6F001EB098 /* TSCPickerComponent.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1A6955A1B96FF6F001EB098 /* TSCPickerComponent.m in Sources */ = {isa = PBXBuildFile; fileRef = B1A695541B96FF6F001EB098 /* TSCPickerComponent.m */; };
@@ -100,6 +101,7 @@
 		493EED3F1BB4086D004FB9A3 /* TSCStoryboardRow.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSCStoryboardRow.m; sourceTree = "<group>"; };
 		B140B00F1C44023E00F108CE /* TSCDatePickerView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TSCDatePickerView.xib; sourceTree = "<group>"; };
 		B140B0111C44034100F108CE /* TSCDatePickerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TSCDatePickerView.swift; sourceTree = "<group>"; };
+		B15560FD1CBE49B400834825 /* ApplicationLoadingIndicatorManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationLoadingIndicatorManager.swift; sourceTree = "<group>"; };
 		B1A695511B96F95D001EB098 /* TSCTheme.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSCTheme.m; sourceTree = "<group>"; };
 		B1A695531B96FF6F001EB098 /* TSCPickerComponent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSCPickerComponent.h; sourceTree = "<group>"; };
 		B1A695541B96FF6F001EB098 /* TSCPickerComponent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSCPickerComponent.m; sourceTree = "<group>"; };
@@ -303,6 +305,7 @@
 		C2E509BF19C83A5300350F00 /* Images */ = {
 			isa = PBXGroup;
 			children = (
+				B15560FD1CBE49B400834825 /* ApplicationLoadingIndicatorManager.swift */,
 				C2E509B319C83A4D00350F00 /* TSCImageController.h */,
 				C2E509B419C83A4D00350F00 /* TSCImageController.m */,
 				C2E509B519C83A4D00350F00 /* TSCImageRequest.h */,
@@ -611,6 +614,7 @@
 				C2E509BC19C83A4D00350F00 /* TSCImageRequest.m in Sources */,
 				C2E50A2119C83B2C00350F00 /* TSCTableInputTextViewRow.m in Sources */,
 				C2E509D219C83A9A00350F00 /* TSCTableValue1ViewCell.m in Sources */,
+				B15560FE1CBE49B400834825 /* ApplicationLoadingIndicatorManager.swift in Sources */,
 				C2E50A0819C83B1700350F00 /* TSCTableImageRow.m in Sources */,
 				C2E509ED19C83ACA00350F00 /* TSCTableInputTextFieldViewCell.m in Sources */,
 			);

--- a/ThunderTable/ApplicationLoadingIndicatorManager.swift
+++ b/ThunderTable/ApplicationLoadingIndicatorManager.swift
@@ -1,0 +1,35 @@
+//
+//  ApplicationLoadingIndicatorManager.swift
+//  ThunderRequest
+//
+//  Created by Simon Mitchell on 13/04/2016.
+//  Copyright © 2016 threesidedcube. All rights reserved.
+//
+
+import UIKit
+
+public class ApplicationLoadingIndicatorManager: NSObject {
+    
+    public static let sharedManager = ApplicationLoadingIndicatorManager()
+    private var activityCount = 0
+        
+    public func showActivityIndicator() {
+        
+        objc_sync_enter(self)
+        if activityCount == 0 {
+            UIApplication.sharedApplication().networkActivityIndicatorVisible = true
+        }
+        activityCount += 1
+        objc_sync_exit(self)
+    }
+    
+    public func hideActivityIndicator() {
+        
+        objc_sync_enter(self)
+        activityCount -= 1
+        if activityCount <= 0 {
+            UIApplication.sharedApplication().networkActivityIndicatorVisible = false
+        }
+        objc_sync_exit(self)
+    }
+}

--- a/ThunderTable/TSCImageController.m
+++ b/ThunderTable/TSCImageController.m
@@ -7,6 +7,7 @@
 //
 
 #import "TSCImageController.h"
+#import <ThunderTable/ThunderTable-Swift.h>
 
 @interface TSCImageController () <NSURLSessionTaskDelegate>
 
@@ -81,6 +82,8 @@ static TSCImageController *sharedController = nil;
 {
     // Check OAuth status before making the request
     __weak typeof(self) welf = self;
+    
+    [ApplicationLoadingIndicatorManager.sharedManager showActivityIndicator];
     [request prepareForDispatch];
     
     if (request.image) {
@@ -93,6 +96,8 @@ static TSCImageController *sharedController = nil;
     
     request.dataTask = [welf.defaultSession dataTaskWithRequest:request completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
         
+        [ApplicationLoadingIndicatorManager.sharedManager hideActivityIndicator];
+
         //Notify of errors
         if (data && [UIImage imageWithData:data]) {
             


### PR DESCRIPTION
…y indicator is managed based on the current number of show/hide requests.

Makes the application loading indicator state more manageable across the framework by creating a shared instance of a controller which manages a count of home many times it has been turned on/off, and turns off the indicator when begins/starts loading an image in TSCImageController
