### PR TITLE
Fixes cell separators on iPad

### DIFF
--- a/ThunderTable/TableViewCell.swift
+++ b/ThunderTable/TableViewCell.swift
@@ -190,7 +190,7 @@ open class TableViewCell: UITableViewCell {
 	//This is really quite awful but it's the only way to get tableview to remove the 1px line at the top of sections on a group tableview when disabling cell seperators
 	override open func addSubview(_ view: UIView) {
 		
-		if !shouldDisplaySeparators && round(view.frame.height * UIScreen.main.scale) == 1 || round(view.frame.height) == 1 {
+		if !shouldDisplaySeparators && (round(view.frame.height * UIScreen.main.scale) == 1 || round(view.frame.height) == 1) {
 			return
 		}
 		


### PR DESCRIPTION
Wraps view height check in brackets to fix cell separators never displaying

on iPad...
turns out on iPad cell separators are 1pt high rather than hairline width
(1 pixel high) which mean that this was only affecting iPad. The brackets
make sure our boolean logic is applied in the way we expected:

if !shouldDisplaySeparators && is1PixelOrPointHigh

rather than:

if (!shouldDisplaySeparators && is1PixelHigh) || is1PointHight