### PR TITLE
Changes default detail font to a more legible size

### DIFF
--- a/ThunderTable/Theme.swift
+++ b/ThunderTable/Theme.swift
@@ -175,7 +175,7 @@ open class Theme: NSObject {
     open var cellTitleFont: UIFont = .preferredFont(forTextStyle: .body)
         
     /// The font for the detail label of cells throughout the app
-    open var cellDetailFont: UIFont = .preferredFont(forTextStyle: .caption1)
+    open var cellDetailFont: UIFont = .preferredFont(forTextStyle: .subheadline)
 
 }
 


### PR DESCRIPTION
Changes the default subtitle font to be more legible across all of our apps. Let's face it, 12pts is too small to be readable on a device.