### PR TITLE
Fix/custom actions

### DIFF
--- a/ThunderTable/TableRow+Actions.swift
+++ b/ThunderTable/TableRow+Actions.swift
@@ -113,8 +113,11 @@ extension RowActionable {
     /// - Parameter handler: The handler to be called.
     /// - Returns: A `UIContextualAction`.
     func contextualAction(with handler: @escaping UIContextualActionHandler) -> UIContextualAction {
+        
         let action = UIContextualAction(style: style._UIContextualActionStyle, title: title, handler: handler)
-        action.backgroundColor = backgroundColor
+        if backgroundColor != nil {
+            action.backgroundColor = backgroundColor
+        }
         action.image = image
         return action
     }
@@ -124,8 +127,11 @@ extension RowActionable {
     /// - Parameter handler: The handler to be called.
     /// - Returns: A `UIContextualAction`.
     func rowAction(with handler: @escaping (UITableViewRowAction, IndexPath) -> Void) -> UITableViewRowAction {
+        
         let rowAction = UITableViewRowAction(style: style._UITableViewRowActionStyle, title: title, handler: handler)
-        rowAction.backgroundColor = backgroundColor
+        if backgroundColor != nil {
+            rowAction.backgroundColor = backgroundColor
+        }
         rowAction.backgroundEffect = backgroundEffect
         return rowAction
     }

--- a/ThunderTable/TableRow+Actions.swift
+++ b/ThunderTable/TableRow+Actions.swift
@@ -115,6 +115,7 @@ extension RowActionable {
     func contextualAction(with handler: @escaping UIContextualActionHandler) -> UIContextualAction {
         
         let action = UIContextualAction(style: style._UIContextualActionStyle, title: title, handler: handler)
+        // Only set this if non-nil otherwise we end up with no default colouring and a transparent background to the button
         if backgroundColor != nil {
             action.backgroundColor = backgroundColor
         }
@@ -129,6 +130,7 @@ extension RowActionable {
     func rowAction(with handler: @escaping (UITableViewRowAction, IndexPath) -> Void) -> UITableViewRowAction {
         
         let rowAction = UITableViewRowAction(style: style._UITableViewRowActionStyle, title: title, handler: handler)
+        // Only set this if non-nil otherwise we end up with no default colouring and a transparent background to the button
         if backgroundColor != nil {
             rowAction.backgroundColor = backgroundColor
         }

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -290,7 +290,14 @@ open class TableViewController: UITableViewController {
 		let section = data[indexPath.section]
 		let row = section.rows[indexPath.row]
 		
-		guard let configuration = row.trailingSwipeActionsConfiguration ?? section.rowTrailingSwipeActionsConfiguration else { return nil }
+		guard let configuration = row.trailingSwipeActionsConfiguration ?? section.rowTrailingSwipeActionsConfiguration else {
+            
+            // Returning nil gives us the default "delete" item, so we only return nil if we don't have an editHandler
+            if section.editHandler == nil && row.editHandler == nil {
+                return []
+            }
+            return nil
+        }
 		
 		return configuration.rowActionsFor(row: row, in: tableView)
 	}
@@ -312,7 +319,15 @@ open class TableViewController: UITableViewController {
 		let section = data[indexPath.section]
 		let row = section.rows[indexPath.row]
 		
-		guard let configuration = row.trailingSwipeActionsConfiguration ?? section.rowTrailingSwipeActionsConfiguration else { return nil }
+		guard let configuration = row.trailingSwipeActionsConfiguration ?? section.rowTrailingSwipeActionsConfiguration else {
+            
+            // Returning nil gives us the default "delete" item, so we only return nil if we don't have an editHandler
+            if section.editHandler == nil && row.editHandler == nil {
+                let emptyConfiguration = UISwipeActionsConfiguration(actions: [])
+                return emptyConfiguration
+            }
+            return nil
+        }
 		
 		return configuration.configurationFor(row: row, at: indexPath, in: tableView)
 	}


### PR DESCRIPTION
Whilst working on a demo project for the repo and playing around with the actions a bit more than my initial implementation I realised there were a couple of bugs. Namely if you return `nil` from `trailingSwipeActionsConfigurationForRowAt` then you get the standard delete button which is not necessarily what we want from our implementation. Therefore we should return `nil` only if the section or row has an `editHandler` callback.

Also the `backgroundColor` property should only be set on the action if it is non-nil because setting it to nil results in a transparent background to the action.