### PR TITLE
Feature/get set removal

### DIFF
--- a/ThunderTable/Extensions.swift
+++ b/ThunderTable/Extensions.swift
@@ -11,29 +11,20 @@ import Foundation
 extension Array : Section {
     
     public var rows: [Row] {
-        get {
-            return filter({ (item) -> Bool in
-                return item is Row
-            }) as? [Row] ?? []
-        }
-        set {}
+        return filter({ (item) -> Bool in
+            return item is Row
+        }) as? [Row] ?? []
     }
     
     public var editHandler: EditHandler? {
-        get {
-            return nil
-        }
-        set {}
+        return nil
     }
 }
 
 extension String: PickerRowDisplayable {
     
     public var rowTitle: String {
-        get {
-            return self
-        }
-        set {}
+        return self
     }
     
     public var value: AnyHashable {
@@ -44,9 +35,7 @@ extension String: PickerRowDisplayable {
 extension Int: PickerRowDisplayable {
     
     public var rowTitle: String {
-        get {
-            return "\(self)"
-        }
+        return "\(self)"
     }
     
     public var value: AnyHashable {
@@ -57,9 +46,7 @@ extension Int: PickerRowDisplayable {
 extension Double: PickerRowDisplayable {
     
     public var rowTitle: String {
-        get {
-            return "\(self)"
-        }
+        return "\(self)"
     }
     
     public var value: AnyHashable {
@@ -70,7 +57,6 @@ extension Double: PickerRowDisplayable {
 extension String : Row {
     
     public var title: String? {
-        get { return self }
-        set {}
+        return self
     }
 }

--- a/ThunderTable/TableRow.swift
+++ b/ThunderTable/TableRow.swift
@@ -16,24 +16,24 @@ public protocol Row {
 	/// - Important: If you wish to return `.none` from this, make sure to use the long syntax:
 	/// `UITableViewCellAccessoryType.none` otherwise the compiler will think you are returning
 	/// `Optional.none` which is equivalent to nil and therefore will be ignored by `TableViewController`
-	var accessoryType: UITableViewCellAccessoryType? { get set }
+	var accessoryType: UITableViewCellAccessoryType? { get }
 	
 	/// The selection style to be applied when the cell for this row is pressed down
 	/// - Important: If you wish to return `.none` from this, make sure to use the long syntax:
 	/// `UITableViewCellSelectionStyle.none` otherwise the compiler will think you are returning
 	/// `Optional.none` which is equivalent to nil and therefore will be ignored by `TableViewController`
-	var selectionStyle: UITableViewCellSelectionStyle? { get set }
+	var selectionStyle: UITableViewCellSelectionStyle? { get }
 	
 	/// The cell style of the cell for this row
 	///
 	/// - Important: This will only take affect if you directly use TableRow, or subclass `TableViewCell` but don't use a xib based layout and return false from `useNibSuperclass`.
-	var cellStyle: UITableViewCellStyle? { get set }
+	var cellStyle: UITableViewCellStyle? { get }
 	
     /// A string to be displayed as the title for the row
-    var title: String? { get set }
+    var title: String? { get }
 	
     /// A string to be displayed as the subtitle for the row
-    var subtitle: String? { get set }
+    var subtitle: String? { get }
     
     /// An image to be displayed in the row
     var image: UIImage? { get set }
@@ -45,7 +45,7 @@ public protocol Row {
     var imageSize: CGSize? { get }
     
     /// A url to load the image for the cell from
-    var imageURL: URL? { get set }
+    var imageURL: URL? { get }
     
     /// Whether the cell should remain selected when pressed by the user
 	///
@@ -55,12 +55,12 @@ public protocol Row {
 	/// Whether separators should be displayed on the cell
 	///
 	/// Defaults to true
-	var displaySeparators: Bool { get set }
+	var displaySeparators: Bool { get }
 	
 	/// Whether the row is editable (Shows delete/actions) on cell swipe
 	///
 	/// Defaults to false
-	var isEditable: Bool { get set }
+	var isEditable: Bool { get }
     
     /// The class for the `UITableViewCell` subclass for the cell
     var cellClass: AnyClass? { get }
@@ -70,10 +70,10 @@ public protocol Row {
     var prototypeIdentifier: String? { get }
     
     /// A closure which will be called when the row is pressed on in the table view
-    var selectionHandler: SelectionHandler? { get set }
+    var selectionHandler: SelectionHandler? { get }
 	
 	/// A closure which will be called when the row is edited in the table view
-	var editHandler: EditHandler? { get set }
+	var editHandler: EditHandler? { get }
     
     /// The estimated height of the row
 	///
@@ -127,38 +127,31 @@ public protocol Row {
 extension Row {
 	
 	public var accessoryType: UITableViewCellAccessoryType? {
-		get { return nil }
-		set {}
+		return nil
 	}
 	
 	public var selectionStyle: UITableViewCellSelectionStyle? {
-		get { return nil }
-		set {}
+		return nil
 	}
 	
 	public var displaySeparators: Bool {
-		get { return true }
-		set {}
+		return true
 	}
 	
 	public var isEditable: Bool {
-		get { return leadingSwipeActionsConfiguration != nil || trailingSwipeActionsConfiguration != nil || editHandler != nil }
-		set {}
+		return leadingSwipeActionsConfiguration != nil || trailingSwipeActionsConfiguration != nil || editHandler != nil
 	}
 	
 	public var cellStyle: UITableViewCellStyle? {
-		get { return nil }
-		set {}
+		return nil
 	}
     
     public var title: String? {
-		get { return nil }
-		set {}
+		return nil
     }
     
     public var subtitle: String? {
-		get { return nil }
-		set {}
+		return nil
     }
     
     public var image: UIImage? {
@@ -167,8 +160,7 @@ extension Row {
     }
     
     public var imageURL: URL? {
-		get { return nil }
-		set {}
+		return nil
     }
     
     public var imageSize: CGSize? {
@@ -188,13 +180,11 @@ extension Row {
     }
     
     public var selectionHandler: SelectionHandler? {
-		get { return nil }
-		set {}
+		return nil
     }
 	
 	public var editHandler: EditHandler? {
-		get { return nil }
-		set {}
+		return nil
 	}
 	
 	public var useNibSuperclass: Bool {
@@ -217,9 +207,9 @@ extension Row {
 		return nil
 	}
 	
-	public var leadingSwipeActionsConfiguration: SwipeActionsConfigurable? { get { return nil } }
+	public var leadingSwipeActionsConfiguration: SwipeActionsConfigurable? { return nil }
 	
-	public var trailingSwipeActionsConfiguration: SwipeActionsConfigurable? { get { return nil } }
+	public var trailingSwipeActionsConfiguration: SwipeActionsConfigurable? { return nil }
 }
 
 /// A base class which can be subclassed providing a template for the `Row` protocol
@@ -230,10 +220,7 @@ open class TableRow: Row {
 	open var displaySeparators: Bool = true
 	
 	public var isEditable: Bool {
-		get {
-			return leadingSwipeActionsConfiguration != nil || trailingSwipeActionsConfiguration != nil || editHandler != nil
-		}
-		set {}
+        return leadingSwipeActionsConfiguration != nil || trailingSwipeActionsConfiguration != nil || editHandler != nil
 	}
 	
 	public var editHandler: EditHandler?

--- a/ThunderTable/TableSection.swift
+++ b/ThunderTable/TableSection.swift
@@ -14,15 +14,15 @@ public typealias EditHandler = (_ row: Row, _ editingStyle: UITableViewCellEditi
 
 public protocol Section {
     
-    var rows: [Row] { get set }
+    var rows: [Row] { get }
     
-    var header: String? { get set }
+    var header: String? { get }
     
-    var footer: String? { get set }
+    var footer: String? { get }
     
-    var editHandler: EditHandler? { get set }
+    var editHandler: EditHandler? { get }
     
-    var selectionHandler: SelectionHandler? { get set }
+    var selectionHandler: SelectionHandler? { get }
     
     var rowLeadingSwipeActionsConfiguration: SwipeActionsConfigurable? { get }
     
@@ -32,36 +32,24 @@ public protocol Section {
 public extension Section {
     
     var rows: [Row] {
-        get {
-            return []
-        }
-        set {}
+        return []
     }
     
     var header: String? {
-        get {
-            return nil
-        }
-        set {}
+        return nil
     }
     
     var footer: String? {
-        get {
-            return nil
-        }
-        set {}
+        return nil
     }
     
     var selectionHandler: SelectionHandler? {
-        get {
-            return nil
-        }
-        set {}
+        return nil
     }
     
-    var rowLeadingSwipeActionsConfiguration: SwipeActionsConfigurable? { get { return nil } }
+    var rowLeadingSwipeActionsConfiguration: SwipeActionsConfigurable? { return nil }
     
-    var rowTrailingSwipeActionsConfiguration: SwipeActionsConfigurable? { get { return nil } }
+    var rowTrailingSwipeActionsConfiguration: SwipeActionsConfigurable? { return nil }
 }
 
 open class TableSection: Section {


### PR DESCRIPTION
With the `Row` and `Section` protocols as `{ get set }` properties (And the default extensions to make them effectively optional) if you extended a class like so:

```
extension CNContact: Row {
   var title: String? {
      return givenName
   }
}
```

the compiler wouldn't warn you (Because of default extension) but the row would display with a blank title because the added property is not `{ get set }` it is `{ get }`. To fix this, and because the properties don't really need to be `{ get set }` (Other than the special case of `image` on the `Row` protocol) we will change all of them to simply `{ get }`. This allows for all the following syntaxes, and means there is no need to change existing code:

```
class Person: Row {
   var title: String?
}

extension CNContact: Row {
   var title: String? {
      return givenName
   }
}

extension CNContact: Row {
   var title: String? {
      get { return givenName }
   }
}

//AND EVEN
extension CNContact: Row {
    var title: String? {
        get { return givenName }
        set { }
    }
}
``` 