### PR TITLE
Changes AnyClass type of cellClass to UITableViewCell.Type 

### DIFF
--- a/ThunderTable/InputDatePickerRow.swift
+++ b/ThunderTable/InputDatePickerRow.swift
@@ -57,7 +57,7 @@ open class InputDatePickerRow: InputTableRow {
 		}
 	}
 	
-	open override var cellClass: AnyClass? {
+	open override var cellClass: UITableViewCell.Type? {
 		return InputDatePickerViewCell.self
 	}
 	

--- a/ThunderTable/InputPickerRow.swift
+++ b/ThunderTable/InputPickerRow.swift
@@ -89,7 +89,7 @@ open class InputPickerRow: InputTableRow {
         self.title = title
     }
     
-    open override var cellClass: AnyClass? {
+    open override var cellClass: UITableViewCell.Type? {
         return InputPickerViewCell.self
     }
     

--- a/ThunderTable/InputSliderRow.swift
+++ b/ThunderTable/InputSliderRow.swift
@@ -16,7 +16,7 @@ import UIKit
 /// This means `sender.value !== value` in that closure!
 open class InputSliderRow: InputTableRow {
     
-    override open var cellClass: AnyClass? {
+    override open var cellClass: UITableViewCell.Type? {
         return InputSliderViewCell.self
     }
     

--- a/ThunderTable/InputSwitchRow.swift
+++ b/ThunderTable/InputSwitchRow.swift
@@ -14,7 +14,7 @@ open class InputSwitchRow: InputTableRow {
 	
 	public var isUserInteractionEnabled = true
 
-    override open var cellClass: AnyClass? {
+    override open var cellClass: UITableViewCell.Type? {
         return InputSwitchViewCell.self
     }
     

--- a/ThunderTable/InputTableRow.swift
+++ b/ThunderTable/InputTableRow.swift
@@ -83,7 +83,7 @@ open class InputTableRow: NSObject, InputRow {
     
     open var selectionHandler: SelectionHandler?
     
-    open var cellClass: AnyClass? {
+    open var cellClass: UITableViewCell.Type? {
         return TableViewCell.self
     }
     

--- a/ThunderTable/InputTextFieldRow.swift
+++ b/ThunderTable/InputTextFieldRow.swift
@@ -26,7 +26,7 @@ open class InputTextFieldRow: InputTableRow {
     
     open var autocapitalizationType: UITextAutocapitalizationType = .none
     
-    override open var cellClass: AnyClass? {
+    override open var cellClass: UITableViewCell.Type? {
         return InputTextFieldViewCell.self
     }
     

--- a/ThunderTable/InputTextViewRow.swift
+++ b/ThunderTable/InputTextViewRow.swift
@@ -24,7 +24,7 @@ open class InputTextViewRow: InputTableRow {
     
     open var isSecure: Bool = false
     
-    override open var cellClass: AnyClass? {
+    override open var cellClass: UITableViewCell.Type? {
         return InputTextViewCell.self
     }
     

--- a/ThunderTable/TableRow.swift
+++ b/ThunderTable/TableRow.swift
@@ -63,7 +63,7 @@ public protocol Row {
 	var isEditable: Bool { get }
     
     /// The class for the `UITableViewCell` subclass for the cell
-    var cellClass: AnyClass? { get }
+    var cellClass: UITableViewCell.Type? { get }
     
     /// A prototype identifier for a cell which is defined in a storyboard
 	/// file, which this row will use
@@ -171,7 +171,7 @@ extension Row {
         return false
     }
     
-    public var cellClass: AnyClass? {
+    public var cellClass: UITableViewCell.Type? {
         return TableViewCell.self
     }
     
@@ -257,7 +257,7 @@ open class TableRow: Row {
 	
 	open var trailingSwipeActionsConfiguration: SwipeActionsConfigurable?
     
-    open var cellClass: AnyClass? {
+    open var cellClass: UITableViewCell.Type? {
 		guard let cellStyle = cellStyle else { return TableViewCell.self }
 		switch cellStyle {
 		case .default:

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -70,7 +70,7 @@ extension Row {
 				
 				// Sometimes a cell may have subclassed without providing it's own nib file
 				// In this case always use it's superclass!
-				while nibPath == nil, let superClass = cellClass.superclass(){
+				while nibPath == nil, let superClass = cellClass.superclass() as? UITableViewCell.Type {
 					
 					// Make sure we're still looking in the correct bundle
 					bundle = Bundle(for: superClass)
@@ -402,7 +402,7 @@ open class TableViewController: UITableViewController {
         var cell = dynamicHeightCells[identifier]
         if cell == nil {
             
-            if let aClass = row.cellClass as? UITableViewCell.Type {
+            if let aClass = row.cellClass {
                 cell = aClass.init(style: .default, reuseIdentifier: identifier)
             }
         }


### PR DESCRIPTION
Hey, 

I've been playing with swifty ThunderTable for some personal projects and figured I would drop a PR on something I noticed :)

This PR changes `cellClass` property on the Row protocol from `AnyClass` to `UITableViewCell.Type`. 
This restricts the property to only UITableViewCell and any subclasses types, which is handy when you have a project mixed with UICollectionViewCells.

I realise this will break any project's Row objects, but it is easily fixed with a quick find & replace on the project.

I've tested the change on the demo_project branch and haven't seen any issues.