### PR TITLE
Fixes an issue where didSet of data is called recursively in swift 4.1

### DIFF
--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -106,9 +106,15 @@ extension Row {
 
 open class TableViewController: UITableViewController {
     
-    open var data: [Section] = [] {
-        didSet {
+    private var _data: [Section] = []
+    
+    open var data: [Section] {
+        set {
+            _data = newValue
             tableView.reloadData()
+        }
+        get {
+            return _data
         }
     }
 	
@@ -116,7 +122,7 @@ open class TableViewController: UITableViewController {
 	
 	public var selectedRows: [Row]? {
 		return tableView.indexPathsForSelectedRows?.map({ (indexPath) -> Row in
-			return data[indexPath.section].rows[indexPath.row]
+			return _data[indexPath.section].rows[indexPath.row]
 		})
 	}
     
@@ -149,7 +155,7 @@ open class TableViewController: UITableViewController {
     
     public var inputDictionary: [String: Any?]? {
         
-        guard let inputRows = data.flatMap({ $0.rows.filter({ $0 as? InputRow != nil }) }) as? [InputRow] else { return nil }
+        guard let inputRows = _data.flatMap({ $0.rows.filter({ $0 as? InputRow != nil }) }) as? [InputRow] else { return nil }
         
         var dictionary: [String: Any?] = [:]
         
@@ -162,7 +168,7 @@ open class TableViewController: UITableViewController {
 	
 	public var missingRequiredInputRows: [InputRow]? {
 		
-		guard let inputRows = data.flatMap({ $0.rows.filter({ $0 as? InputRow != nil }) }) as? [InputRow] else { return nil }
+		guard let inputRows = _data.flatMap({ $0.rows.filter({ $0 as? InputRow != nil }) }) as? [InputRow] else { return nil }
 		
 		return inputRows.filter({ (inputRow) -> Bool in
 			return inputRow.required && inputRow.value == nil
@@ -256,14 +262,14 @@ open class TableViewController: UITableViewController {
 
     override open func numberOfSections(in tableView: UITableView) -> Int {
         
-        return data.count
+        return _data.count
     }
 
     override open func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         
-        if section - 1 > data.count { return 0 }
+        if section - 1 > _data.count { return 0 }
         
-        let section = data[section]
+        let section = _data[section]
         return section.rows.count
     }
 
@@ -334,7 +340,7 @@ open class TableViewController: UITableViewController {
 		
     override open func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         
-        let row = data[indexPath.section].rows[indexPath.row]
+        let row = _data[indexPath.section].rows[indexPath.row]
         
         var identifier: String = "Cell"
         
@@ -365,7 +371,7 @@ open class TableViewController: UITableViewController {
     
     override open func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
         
-        let row = data[indexPath.section].rows[indexPath.row]
+        let row = _data[indexPath.section].rows[indexPath.row]
         
         if let estimatedHeight = row.estimatedHeight {
             return estimatedHeight
@@ -378,7 +384,7 @@ open class TableViewController: UITableViewController {
     
     override open func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         
-        let row = data[indexPath.section].rows[indexPath.row]
+        let row = _data[indexPath.section].rows[indexPath.row]
         
         // If they're using prototype cells or nibs then we don't want to manually calculate size
         let calculateSize = row.prototypeIdentifier == nil && row.nib == nil
@@ -446,13 +452,13 @@ open class TableViewController: UITableViewController {
 	
 	override open func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
 		
-		let section = data[section]
+		let section = _data[section]
 		return section.header
 	}
 	
 	override open func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
 		
-		let section = data[section]
+		let section = _data[section]
 		return section.footer
 	}
 
@@ -527,7 +533,7 @@ public extension TableViewController {
 	
     internal func selectable(_ indexPath: IndexPath) -> Bool {
 		
-        let section = data[indexPath.section]
+        let section = _data[indexPath.section]
         let row = section.rows[indexPath.row]
         
         return row.selectionHandler != nil || section.selectionHandler != nil || (row as? InputRow) != nil
@@ -535,7 +541,7 @@ public extension TableViewController {
     
     internal func set(indexPath: IndexPath, selected: Bool) {
         
-        let section = data[indexPath.section]
+        let section = _data[indexPath.section]
         let row = section.rows[indexPath.row]
         
         // Row selection overrides section selection


### PR DESCRIPTION
This fixes an issue where in Swift 4.1 the `didSet` method of `data` method was called continuously if any of the code the redraw calls mutates anything in the array of data items, see swift bug report [here](https://bugs.swift.org/browse/SR-7335).

This is fairly simple to fix by having the public `data` property being a calculated var which uses an internal private equivalent used by the methods in TableViewController.

It's possible we will be able to undo this change in a later version of swift.