### PR TITLE
Fixes setting of paragraph style on cell's labels

### DIFF
--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -26,14 +26,15 @@ extension UILabel {
 					attributes[.foregroundColor] = textColor
 				}
 				
-				attributes[.paragraphStyle] = paragraphStyle
+				attributes[.paragraphStyle] = newValue
 				
 				let attributedString = NSAttributedString(string: text, attributes: attributes)
 				attributedText = attributedString
 			}
 		}
 		get {
-			return NSParagraphStyle()
+            guard let paragraphAttribute = attributedText?.attribute(.paragraphStyle, at: 0, effectiveRange: nil) else { return nil }
+            return paragraphAttribute as? NSParagraphStyle
 		}
 	}
 }


### PR DESCRIPTION
Changes setting of UILabel paragraphStyle to use `newValue` in the setter, because it was previously using `paragraphStyle` which is the value **after** the setter has run!