### PR TITLE
Fixes crash in image loading

### DIFF
--- a/ThunderTable/ImageView.swift
+++ b/ThunderTable/ImageView.swift
@@ -185,8 +185,11 @@ public extension UIImageView {
                             }
                         })
                         
-                        // Remove this image request from the queued requests
-                        welf.requests?.remove(at: requestIndex)
+                        // Remove this image request from the queued requests, recalculate index,
+                        // because above code may have broken the ordering!
+                        if let index = welf.requests?.index(where: { $0.urlRequest == request?.urlRequest }) {
+                            welf.requests?.remove(at: index)
+                        }
                     }
                 }
                 


### PR DESCRIPTION
Fixes image load removal due to indexes of items changing. The indices could change if for some reason a larger image loaded before a smaller one. This re-calculates the index meaning we don't get index out of bounds or similar!