### PR TITLE
Updates ImageController so it doesn't wrongly set the image scale

### DIFF
--- a/ThunderTable/ImageController.swift
+++ b/ThunderTable/ImageController.swift
@@ -69,7 +69,7 @@ open class ImageController {
                 return
             }
             
-            guard let image = UIImage(data: data, scale: UIScreen.main.scale) else {
+            guard let image = UIImage(data: data) else {
                 
                 OperationQueue.main.addOperation {
                     withCompletion?(nil, ImageControllerError.invalidData, request)


### PR DESCRIPTION
As of iOS 13 SDK it seems that initialising an image with data and a scale based on the devices screen can cause issues further down the line, like when rendering the image it returns `size` at a given value (100x200) but renders at it's full original value (@2x -> 200x400) meaning the image Is cropped. I don't believe we need to provide the `scale` here when allocating the image!