### PR TITLE
Improves image loading callback customisation

### DIFF
--- a/ThunderTable/ImageView.swift
+++ b/ThunderTable/ImageView.swift
@@ -130,8 +130,9 @@ public extension UIImageView {
     /// - parameter withPlaceholder: The image to use as a placeholder for the loading image (Optional)
     /// - parameter imageSize:       The size of the final image which will be loaded from the URL
     /// - parameter animated:        Whether the loading image should animate in when retrieved
+    /// - parameter callCompletionForIntermediataryLoads: Whether `completion` should be called for intermediatary image loads
     /// - parameter completion:      A closure which will be called upon the completed load of the image.
-    func set(imageURLS: [URL]?, withPlaceholder: UIImage?, imageSize: CGSize = CGSize.zero, animated: Bool = false, completion: ImageViewSetImageURLCompletion?) {
+    func set(imageURLS: [URL]?, withPlaceholder: UIImage?, imageSize: CGSize = CGSize.zero, animated: Bool = false, callCompletionForIntermediataryLoads: Bool = false, completion: ImageViewSetImageURLCompletion?) {
         
         finalSize = imageSize
         cancelCurrentRequestOperations()
@@ -200,6 +201,10 @@ public extension UIImageView {
                     welf.imageURLS = nil
                     welf.completion?(image, error)
                     welf.completion = nil
+                    
+                } else if callCompletionForIntermediataryLoads {
+                    
+                    welf.completion?(image, error)
                 }
             })
         })

--- a/ThunderTable/ImageView.swift
+++ b/ThunderTable/ImageView.swift
@@ -130,9 +130,9 @@ public extension UIImageView {
     /// - parameter withPlaceholder: The image to use as a placeholder for the loading image (Optional)
     /// - parameter imageSize:       The size of the final image which will be loaded from the URL
     /// - parameter animated:        Whether the loading image should animate in when retrieved
-    /// - parameter callCompletionForIntermediataryLoads: Whether `completion` should be called for intermediatary image loads
+    /// - parameter callCompletionForIntermediaryLoads: Whether `completion` should be called for intermediary image loads
     /// - parameter completion:      A closure which will be called upon the completed load of the image.
-    func set(imageURLS: [URL]?, withPlaceholder: UIImage?, imageSize: CGSize = CGSize.zero, animated: Bool = false, callCompletionForIntermediataryLoads: Bool = false, completion: ImageViewSetImageURLCompletion?) {
+    func set(imageURLS: [URL]?, withPlaceholder: UIImage?, imageSize: CGSize = CGSize.zero, animated: Bool = false, callCompletionForIntermediaryLoads: Bool = false, completion: ImageViewSetImageURLCompletion?) {
         
         finalSize = imageSize
         cancelCurrentRequestOperations()
@@ -202,7 +202,7 @@ public extension UIImageView {
                     welf.completion?(image, error)
                     welf.completion = nil
                     
-                } else if callCompletionForIntermediataryLoads {
+                } else if callCompletionForIntermediaryLoads {
                     
                     welf.completion?(image, error)
                 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Adds option to setImageURLs to force the completion block to be called on each image load rather than just the first!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves issue when you may want to show progressively large images as a loading mechanism

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in my personal app when loading image previews (Camrote)... In production!

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
