### PR TITLE
Adds placeholderImage property to `Row` protocol

### DIFF
--- a/ThunderTable/TableRow.swift
+++ b/ThunderTable/TableRow.swift
@@ -44,6 +44,9 @@ public protocol Row {
     /// An image to be displayed in the row
     var image: UIImage? { get set }
     
+    /// An image to be used as placeholder when using asynchronous image loading and `image` is nil
+    var placeholderImage: UIImage? { get }
+    
     /// The size of the image which will be displayed in the row
 	/// 
 	/// This will be used when displaying an image using imageURL in order
@@ -168,6 +171,10 @@ extension Row {
         return nil
     }
     
+    public var placeholderImage: UIImage? {
+        return nil
+    }
+    
     public var image: UIImage? {
         get { return nil }
         set {}
@@ -252,6 +259,8 @@ open class TableRow: Row {
     open var accessibilitySubtitle: String?
     
     open var image: UIImage?
+    
+    open var placeholderImage: UIImage?
     
     open var imageSize: CGSize?
     

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -310,11 +310,15 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
             size = imageSize
         }
         
-        imageView?.set(imageURL: row.imageURL, withPlaceholder: row.image, imageSize: size, animated: true, completion: { [weak self] (image, error) -> (Void) in
-            
-            if let welf = self, _row.image == nil {
+        imageView?.set(
+            imageURL: row.imageURL,
+            withPlaceholder: row.image ?? row.placeholderImage,
+            imageSize: size,
+            animated: true,
+            completion: { [weak self] (image, error) -> (Void) in
+            if _row.image == nil {
                 _row.image = image
-                welf.tableView.reloadRows(at: [indexPath], with: .none)
+                self?.tableView.reloadRows(at: [indexPath], with: .none)
             }
         })
 		

--- a/ThunderTableDemo/ViewController.swift
+++ b/ThunderTableDemo/ViewController.swift
@@ -70,6 +70,11 @@ class ViewController: TableViewController {
         let imageRow = TableRow(title: "Bundled Image", subtitle: "With Footer", image: #imageLiteral(resourceName: "logo"), selectionHandler: nil)
         let remoteImageRow = TableRow(title: "Remote Image")
         remoteImageRow.imageURL = URL(string: "http://via.placeholder.com/120x80")
+        remoteImageRow.imageSize = .init(width: 120, height: 80)
+        
+        let remoteImageWithPlaceholderRow = TableRow(title: "Remote Image w/ Placeholder")
+        remoteImageWithPlaceholderRow.placeholderImage = #imageLiteral(resourceName: "logo")
+        remoteImageWithPlaceholderRow.imageURL = URL(string: "http://via.placeholder.com/80x80")
         
         let actionRow = TableRow(title: "Show Alert", subtitle: nil, image: nil) { (row, selected, indexPath, tableView) -> (Void) in
             
@@ -79,7 +84,7 @@ class ViewController: TableViewController {
             self.present(alertViewController, animated: true, completion: nil)
         }
         
-        let basicsSection = TableSection(rows: [row, subtitleRow, imageRow, remoteImageRow, actionRow], header: "Header", footer: "Footer", selectionHandler: nil)
+        let basicsSection = TableSection(rows: [row, subtitleRow, imageRow, remoteImageRow, remoteImageWithPlaceholderRow, actionRow], header: "Header", footer: "Footer", selectionHandler: nil)
         
         return basicsSection
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This solves an issue I was having with `didSet` not being called on a struct/class/enum implementing the `Row` protocol.

If you want the image view to have a placeholder image, previously the easiest way was to return this placeholder from the `image` property. However, `ThunderTable` does a check for `nil` on the row's image before setting `image` after an asynchronous image load and therefore `didSet` on `image` was never called!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves problems around loading images for rows

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested in the example project
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
