### PR TITLE
Adds a scroll offset manager class which caches and restores scroll offsets

### DIFF
--- a/ThunderTable.xcodeproj/project.pbxproj
+++ b/ThunderTable.xcodeproj/project.pbxproj
@@ -44,6 +44,12 @@
 		B1AD7EC31D8C194400BFCA34 /* InputSwitchRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AD7EC21D8C194400BFCA34 /* InputSwitchRow.swift */; };
 		B1AD7EC61D8C198F00BFCA34 /* InputSwitchViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1AD7EC41D8C198F00BFCA34 /* InputSwitchViewCell.swift */; };
 		B1AD7EC71D8C198F00BFCA34 /* InputSwitchViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1AD7EC51D8C198F00BFCA34 /* InputSwitchViewCell.xib */; };
+		B1B5C6D624FFCAAD00F05CE8 /* ScrollOffsetManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5C6D424FFCAAD00F05CE8 /* ScrollOffsetManager.swift */; };
+		B1B5C6D724FFCAAD00F05CE8 /* ScrollOffsetManagable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5C6D524FFCAAD00F05CE8 /* ScrollOffsetManagable.swift */; };
+		B1B5C6DA24FFD6DB00F05CE8 /* CollectionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5C6D824FFD6DB00F05CE8 /* CollectionTableViewCell.swift */; };
+		B1B5C6DB24FFD6DB00F05CE8 /* CollectionTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1B5C6D924FFD6DB00F05CE8 /* CollectionTableViewCell.xib */; };
+		B1B5C6DD24FFDBED00F05CE8 /* CollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5C6DC24FFDBED00F05CE8 /* CollectionViewCell.swift */; };
+		B1B5C6DF24FFDC4000F05CE8 /* CollectionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B5C6DE24FFDC4000F05CE8 /* CollectionRow.swift */; };
 		B1B679611D89807A00B66FD8 /* TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B6795F1D89807A00B66FD8 /* TableViewCell.swift */; };
 		B1B679621D89807A00B66FD8 /* TableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1B679601D89807A00B66FD8 /* TableViewCell.xib */; };
 		B1BAABCA22244B94007F0F61 /* ContactTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BAABC822244B94007F0F61 /* ContactTableViewCell.swift */; };
@@ -128,6 +134,12 @@
 		B1AD7EC21D8C194400BFCA34 /* InputSwitchRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSwitchRow.swift; sourceTree = "<group>"; };
 		B1AD7EC41D8C198F00BFCA34 /* InputSwitchViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSwitchViewCell.swift; sourceTree = "<group>"; };
 		B1AD7EC51D8C198F00BFCA34 /* InputSwitchViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InputSwitchViewCell.xib; sourceTree = "<group>"; };
+		B1B5C6D424FFCAAD00F05CE8 /* ScrollOffsetManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollOffsetManager.swift; sourceTree = "<group>"; };
+		B1B5C6D524FFCAAD00F05CE8 /* ScrollOffsetManagable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollOffsetManagable.swift; sourceTree = "<group>"; };
+		B1B5C6D824FFD6DB00F05CE8 /* CollectionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionTableViewCell.swift; sourceTree = "<group>"; };
+		B1B5C6D924FFD6DB00F05CE8 /* CollectionTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CollectionTableViewCell.xib; sourceTree = "<group>"; };
+		B1B5C6DC24FFDBED00F05CE8 /* CollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionViewCell.swift; sourceTree = "<group>"; };
+		B1B5C6DE24FFDC4000F05CE8 /* CollectionRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollectionRow.swift; sourceTree = "<group>"; };
 		B1B6795F1D89807A00B66FD8 /* TableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewCell.swift; sourceTree = "<group>"; };
 		B1B679601D89807A00B66FD8 /* TableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TableViewCell.xib; sourceTree = "<group>"; };
 		B1BAABC822244B94007F0F61 /* ContactTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactTableViewCell.swift; sourceTree = "<group>"; };
@@ -196,6 +208,7 @@
 			children = (
 				B11CEB79204977A2001308B3 /* CNContact+Row.swift */,
 				B1BAABCE22244C06007F0F61 /* CNContact+Section.swift */,
+				B1B5C6DE24FFDC4000F05CE8 /* CollectionRow.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -205,6 +218,9 @@
 			children = (
 				B1BAABCC22244BAF007F0F61 /* ContactTableViewCell.xib */,
 				B1BAABC822244B94007F0F61 /* ContactTableViewCell.swift */,
+				B1B5C6D824FFD6DB00F05CE8 /* CollectionTableViewCell.swift */,
+				B1B5C6D924FFD6DB00F05CE8 /* CollectionTableViewCell.xib */,
+				B1B5C6DC24FFDBED00F05CE8 /* CollectionViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -248,6 +264,7 @@
 		B17BAA341D89639100844421 /* ThunderTable */ = {
 			isa = PBXGroup;
 			children = (
+				B1B5C6D324FFCA8C00F05CE8 /* Scroll Offset Caching */,
 				B1D10CD01DA540CF003FBCB4 /* Theme.swift */,
 				B19C53261D8B036600B30A35 /* ApplicationLoadingIndicatorManager.swift */,
 				B1E0883B1DA638B400E45E47 /* Images */,
@@ -303,6 +320,15 @@
 				B1784D851D8C3A8A007358EA /* InputSliderViewCell.xib */,
 			);
 			name = Cells;
+			sourceTree = "<group>";
+		};
+		B1B5C6D324FFCA8C00F05CE8 /* Scroll Offset Caching */ = {
+			isa = PBXGroup;
+			children = (
+				B1B5C6D524FFCAAD00F05CE8 /* ScrollOffsetManagable.swift */,
+				B1B5C6D424FFCAAD00F05CE8 /* ScrollOffsetManager.swift */,
+			);
+			name = "Scroll Offset Caching";
 			sourceTree = "<group>";
 		};
 		B1E0883B1DA638B400E45E47 /* Images */ = {
@@ -454,6 +480,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B1B5C6DB24FFD6DB00F05CE8 /* CollectionTableViewCell.xib in Resources */,
 				B14F945B20444E820014F694 /* LaunchScreen.storyboard in Resources */,
 				B14F945820444E820014F694 /* Assets.xcassets in Resources */,
 				B1BAABCD22244BAF007F0F61 /* ContactTableViewCell.xib in Resources */,
@@ -495,7 +522,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				B1BAABCA22244B94007F0F61 /* ContactTableViewCell.swift in Sources */,
+				B1B5C6DA24FFD6DB00F05CE8 /* CollectionTableViewCell.swift in Sources */,
+				B1B5C6DF24FFDC4000F05CE8 /* CollectionRow.swift in Sources */,
 				B1BAABCF22244C06007F0F61 /* CNContact+Section.swift in Sources */,
+				B1B5C6DD24FFDBED00F05CE8 /* CollectionViewCell.swift in Sources */,
 				B14F945320444E820014F694 /* ViewController.swift in Sources */,
 				B14F945120444E820014F694 /* AppDelegate.swift in Sources */,
 				B11CEB9F20498F0C001308B3 /* CNContact+Row.swift in Sources */,
@@ -511,6 +541,7 @@
 				B1784D831D8C3A60007358EA /* InputSliderRow.swift in Sources */,
 				B1C2C56C1FFCEE3100D968C5 /* InputDatePickerRow.swift in Sources */,
 				B1EC81021FDE86BF00C8EE72 /* SubtitleTableViewCell.swift in Sources */,
+				B1B5C6D724FFCAAD00F05CE8 /* ScrollOffsetManagable.swift in Sources */,
 				B1B679611D89807A00B66FD8 /* TableViewCell.swift in Sources */,
 				B1784D861D8C3A8A007358EA /* InputSliderViewCell.swift in Sources */,
 				B1C2C56F1FFCF20F00D968C5 /* InputDatePickerViewCell.swift in Sources */,
@@ -521,6 +552,7 @@
 				B114F10E2035CA75005D52F2 /* InputPickerRow.swift in Sources */,
 				B1EC81061FDE873700C8EE72 /* Value1TableViewCell.swift in Sources */,
 				B19C53241D8B033E00B30A35 /* InputTextFieldViewCell.swift in Sources */,
+				B1B5C6D624FFCAAD00F05CE8 /* ScrollOffsetManager.swift in Sources */,
 				B1EC80FE1FDE85EA00C8EE72 /* DefaultTableViewCell.swift in Sources */,
 				B1AD7EC61D8C198F00BFCA34 /* InputSwitchViewCell.swift in Sources */,
 				B1E0883D1DA638CE00E45E47 /* ImageView.swift in Sources */,

--- a/ThunderTable/Extensions.swift
+++ b/ThunderTable/Extensions.swift
@@ -8,6 +8,19 @@
 
 import Foundation
 
+extension Array where Element == Section {
+    
+    /// Returns the full set of index paths that cover the array of sections
+    var indexPaths: [IndexPath] {
+        return enumerated().map { (offset, element) -> [IndexPath] in
+            let rows = element.rows
+            return (0..<rows.count).map { (row) -> IndexPath in
+                return IndexPath(row: row, section: offset)
+            }
+        }.flatMap({ $0 })
+    }
+}
+
 extension Array : Section {
     
     public var rows: [Row] {

--- a/ThunderTable/ScrollOffsetManagable.swift
+++ b/ThunderTable/ScrollOffsetManagable.swift
@@ -1,0 +1,35 @@
+//
+//  ScrollDelegatable.swift
+//  ThunderTable
+//
+//  Created by Simon Mitchell on 02/09/2020.
+//  Copyright © 2020 threesidedcube. All rights reserved.
+//
+
+import UIKit
+
+/// A simpler version of `UIScrollViewDelegate` so we don't intefere
+/// with users `UIScrollViewDelegate` implementations
+public protocol ScrollOffsetDelegate: class {
+    
+    /// Called when the content offset of the scroll view changes due to `scrollViewDidScroll`
+    /// - Parameters:
+    ///   - scrollable: The scrollable that the change was for
+    func scrollViewDidChangeContentOffset(_ scrollable: ScrollOffsetManagable)
+}
+
+/// A protocol implemented to allow control and listening to scroll view offset changes
+/// by `ScrollOfffsetManager`
+public protocol ScrollOffsetManagable: class {
+    
+    /// The scroll view that is controllable on the object
+    var scrollView: UIScrollView? { get }
+    
+    /// The delegate to have scroll view delegate methods passed to, this should be a `weak`
+    /// property to avoid retain cycles.
+    /// - Warning: It is your job to call the method on this delegate from your scrollViewDidScroll method.
+    var scrollDelegate: ScrollOffsetDelegate? { get set }
+    
+    /// An identifier used by `ScrollOffsetManager`
+    var identifier: AnyHashable? { get set }
+}

--- a/ThunderTable/ScrollOffsetManager.swift
+++ b/ThunderTable/ScrollOffsetManager.swift
@@ -1,0 +1,75 @@
+//
+//  ScrollOffsetManager.swift
+//  ThunderTable
+//
+//  Created by Simon Mitchell on 02/09/2020.
+//  Copyright © 2020 threesidedcube. All rights reserved.
+//
+
+import CoreGraphics
+import Foundation
+
+/// Scroll offset manager manages caching scroll offsets for UI in any scenario where
+/// scroll views may be re-used and so we need to store their current offset in memory
+/// to avoid re-use issues.
+class ScrollOffsetManager {
+    
+    private var offsetMap: [AnyHashable : CGPoint] = [:]
+    
+    /// Registers the scrollable to the manager for listening for scroll offset changes
+    /// - Parameters:
+    ///   - scrollable: The scrollable to register
+    func register(
+        scrollable: ScrollOffsetManagable
+    ) {
+        scrollable.scrollDelegate = self
+    }
+    
+    /// Caches the offset for the given scrollable
+    /// - Parameters:
+    ///   - scrollable: The scrollable to update the content offset for
+    func updateCachedOffset(scrollable: ScrollOffsetManagable) {
+        guard let identifier = scrollable.identifier else { return }
+        offsetMap[identifier] = scrollable.scrollView?.contentOffset
+    }
+    
+    /// Sets the content offset on the given scrollable from the internal cache
+    /// - Parameters:
+    ///   - scrollable: The scrollable to adjust the content offset on
+    ///   - animated: Whether the transition should animate
+    ///   - fallback: A fallback to set the content offset to if there is no cached value
+    func setScrollOffset(
+        _ scrollable: ScrollOffsetManagable,
+        animated: Bool = false,
+        fallback: CGPoint? = nil
+    ) {
+        guard let identifier = scrollable.identifier else { return }
+        guard let newOffset = offsetMap[identifier] ?? fallback else { return }
+        
+        guard let scrollView = scrollable.scrollView else { return }
+        
+        // Disable then re-enable scroll indicators otherwise calling setContentOffset flashes the scroll indicators
+        let preShowVerticalScrollIndicator = scrollView.showsVerticalScrollIndicator
+        let preShowHorizontalScrollIndicator = scrollView.showsHorizontalScrollIndicator
+        
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        
+        scrollable.scrollView?.setContentOffset(newOffset, animated: animated)
+        
+        scrollView.showsVerticalScrollIndicator = preShowVerticalScrollIndicator
+        scrollView.showsHorizontalScrollIndicator = preShowHorizontalScrollIndicator
+    }
+    
+    /// Resets all content offsets by removing them from the offset map
+    func resetAllOffsets() {
+        offsetMap = [:]
+    }
+}
+
+extension ScrollOffsetManager: ScrollOffsetDelegate {
+    
+    func scrollViewDidChangeContentOffset(_ scrollable: ScrollOffsetManagable) {
+        updateCachedOffset(scrollable: scrollable)
+    }
+}

--- a/ThunderTable/ScrollOffsetManager.swift
+++ b/ThunderTable/ScrollOffsetManager.swift
@@ -14,6 +14,7 @@ import Foundation
 /// to avoid re-use issues.
 class ScrollOffsetManager {
     
+    /// Internal cache for scroll view offsets
     private var offsetMap: [AnyHashable : CGPoint] = [:]
     
     /// Registers the scrollable to the manager for listening for scroll offset changes

--- a/ThunderTable/ScrollOffsetManager.swift
+++ b/ThunderTable/ScrollOffsetManager.swift
@@ -56,7 +56,7 @@ class ScrollOffsetManager {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
         
-        scrollable.scrollView?.setContentOffset(newOffset, animated: animated)
+        scrollView.setContentOffset(newOffset, animated: animated)
         
         scrollView.showsVerticalScrollIndicator = preShowVerticalScrollIndicator
         scrollView.showsHorizontalScrollIndicator = preShowHorizontalScrollIndicator

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -115,7 +115,7 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
         set {
             // If the table view has had rows removed/added
             if newValue.indexPaths != data.indexPaths {
-                scrollOffsetManager.resetAllOffsets()
+                resetEmbeddedScrollOffsets()
             }
             _data = newValue
             tableView.reloadData()
@@ -595,6 +595,22 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
     /// then the cached values will be reset. This may be improved in future if we decide to enforce
     /// row's being `Equatable`.
     public var rememberEmbeddedScrollPositions: Bool = true
+    
+    /// Resets all the "remembered" scroll offsets back to `.zero` for all embedded scrollable cells
+    /// that conform to `ScrollOffsetManagable`.
+    ///
+    /// - Note: This will not actually perform any scrolling on the visible cells (Based on the value provided in `scrollVisibleCells`,
+    /// but they will reset to `.zero` the next time that `cellForRow:` is called regardless of the value provided.
+    /// - Parameter scrollVisibleCells: Whether to scroll the visible cells as well as resetting the cache. Defaults to `false`
+    /// - Parameter animated: If `scrollVisibleCells == true`, whether we should animate the transition. Defaults to `false`
+    public func resetEmbeddedScrollOffsets(scrollingVisibleCells: Bool = false, animated: Bool = false) {
+        scrollOffsetManager.resetAllOffsets()
+        guard scrollingVisibleCells else { return }
+        tableView.visibleCells.forEach { (cell) in
+            guard let scrollable = cell as? ScrollOffsetManagable else { return }
+            scrollable.scrollView?.setContentOffset(.zero, animated: animated)
+        }
+    }
     
     func updateScrollPosition(cell: UITableViewCell, at indexPath: IndexPath) {
         

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -582,9 +582,7 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
     //MARK: Scroll Offset Management
     //MARK:
     
-    private lazy var scrollOffsetManager: ScrollOffsetManager = {
-        ScrollOffsetManager()
-    }()
+    private let scrollOffsetManager: ScrollOffsetManager = ScrollOffsetManager()
     
     /// Whether the table view should keep track of scroll view positions within it's cells.
     /// This allows us to prevent re-use issues with re-using cells that the user has scrolled.

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -610,7 +610,12 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
         }
     }
     
-    func updateScrollPosition(cell: UITableViewCell, at indexPath: IndexPath) {
+    /// Updates the scroll position for the given cell, storing it in `scrollOffsetManager` and actually setting the contentOffset
+    /// - Parameters:
+    ///   - cell: The cell to update scroll for
+    ///   - indexPath: The index path that the cell is at
+    ///   - animated: Whether to animate the setting of scroll offset
+    func updateScrollPosition(cell: UITableViewCell, at indexPath: IndexPath, animated: Bool = false) {
         
         guard rememberEmbeddedScrollPositions, let scrollable = cell as? ScrollOffsetManagable else { return }
         
@@ -619,7 +624,7 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
         // Register the scrollable so it's offset is tracked
         scrollOffsetManager.register(scrollable: scrollable)
         // Set the scroll offset based on `scrollOffsetManager`. This fixes scroll re-use issues.
-        scrollOffsetManager.setScrollOffset(scrollable, animated: false, fallback: .zero)
+        scrollOffsetManager.setScrollOffset(scrollable, animated: animated, fallback: .zero)
     }
     
 	//MARK - variable header/footer size

--- a/ThunderTableDemo/Cells/CollectionTableViewCell.swift
+++ b/ThunderTableDemo/Cells/CollectionTableViewCell.swift
@@ -1,0 +1,33 @@
+//
+//  CollectionTableViewCell.swift
+//  ThunderTableDemo
+//
+//  Created by Simon Mitchell on 02/09/2020.
+//  Copyright © 2020 3SidedCube. All rights reserved.
+//
+
+import UIKit
+import ThunderTable
+
+class CollectionTableViewCell: UITableViewCell, ScrollOffsetManagable, UICollectionViewDelegate {
+    
+    var scrollView: UIScrollView? {
+        return collectionView
+    }
+    
+    weak var scrollDelegate: ScrollOffsetDelegate?
+    
+    var identifier: AnyHashable?
+
+    @IBOutlet weak var collectionView: UICollectionView!
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        collectionView.register(CollectionViewCell.self, forCellWithReuseIdentifier: "Cell")
+        collectionView.delegate = self
+    }
+    
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollDelegate?.scrollViewDidChangeContentOffset(self)
+    }
+}

--- a/ThunderTableDemo/Cells/CollectionTableViewCell.xib
+++ b/ThunderTableDemo/Cells/CollectionTableViewCell.xib
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="65" id="KGk-i7-Jjw" customClass="CollectionTableViewCell" customModule="ThunderTableDemo" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="65"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="F3a-pb-7iU">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="64"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="64" id="NCN-pQ-0mQ"/>
+                        </constraints>
+                        <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="10" id="yBN-k6-tY6">
+                            <size key="itemSize" width="128" height="64"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                    </collectionView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="F3a-pb-7iU" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="2cd-kz-qPu"/>
+                    <constraint firstAttribute="bottom" secondItem="F3a-pb-7iU" secondAttribute="bottom" id="Vvh-ar-x9n"/>
+                    <constraint firstItem="F3a-pb-7iU" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="bae-8f-aKs"/>
+                    <constraint firstAttribute="trailing" secondItem="F3a-pb-7iU" secondAttribute="trailing" id="pSE-54-m41"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="collectionView" destination="F3a-pb-7iU" id="eP9-ns-IvD"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="159.70982142857142"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/ThunderTableDemo/Cells/CollectionViewCell.swift
+++ b/ThunderTableDemo/Cells/CollectionViewCell.swift
@@ -1,0 +1,13 @@
+//
+//  CollectionViewCell.swift
+//  ThunderTableDemo
+//
+//  Created by Simon Mitchell on 02/09/2020.
+//  Copyright © 2020 3SidedCube. All rights reserved.
+//
+
+import UIKit
+
+class CollectionViewCell: UICollectionViewCell {
+    
+}

--- a/ThunderTableDemo/Models/CollectionRow.swift
+++ b/ThunderTableDemo/Models/CollectionRow.swift
@@ -1,0 +1,45 @@
+//
+//  CollectionRow.swift
+//  ThunderTableDemo
+//
+//  Created by Simon Mitchell on 02/09/2020.
+//  Copyright © 2020 3SidedCube. All rights reserved.
+//
+
+import UIKit
+import ThunderTable
+
+class CollectionRow: NSObject, Row, UICollectionViewDataSource {
+        
+    let colours: [UIColor]
+    
+    init(colours: [UIColor]) {
+        self.colours = colours
+        super.init()
+    }
+    
+    func configure(cell: UITableViewCell, at indexPath: IndexPath, in tableViewController: TableViewController) {
+        
+        guard let collectionCell = cell as? CollectionTableViewCell else { return }
+        
+        collectionCell.collectionView.dataSource = self
+    }
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return colours.count
+    }
+    
+    var cellClass: UITableViewCell.Type? {
+        return CollectionTableViewCell.self
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath)
+        cell.backgroundColor = colours[indexPath.item]
+        return cell
+    }
+}

--- a/ThunderTableDemo/ViewController.swift
+++ b/ThunderTableDemo/ViewController.swift
@@ -222,27 +222,9 @@ class ViewController: TableViewController {
     private func collectionScrollReuseSection() -> TableSection {
         
         return TableSection(
-            rows: [
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
-                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText])
-            ],
+            rows: (0..<18).map({ _ in
+                return CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText])
+            }),
             header: "This section exhibits TableViewController's ability to remember and not re-use scroll view offsets"
         )
     }

--- a/ThunderTableDemo/ViewController.swift
+++ b/ThunderTableDemo/ViewController.swift
@@ -27,7 +27,7 @@ class ViewController: TableViewController {
         
         super.viewDidLoad()
         
-        data = [basicsSection(), protocolSection(), contact1, inputSection(), customSection(), actionsSection()]
+        data = [basicsSection(), protocolSection(), contact1, inputSection(), customSection(), actionsSection(), collectionScrollReuseSection()]
     }
     
     
@@ -217,6 +217,34 @@ class ViewController: TableViewController {
         let inputSection = TableSection(rows: [textFieldRow, textViewRow, switchRow, switchRow2, dobRow, countdownRow, timeOfDayRow, sliderRow, viewInputRow, inputPickerRow], header: "Input Rows", footer: nil, selectionHandler: nil)
         
         return inputSection
+    }
+    
+    private func collectionScrollReuseSection() -> TableSection {
+        
+        return TableSection(
+            rows: [
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText]),
+                CollectionRow(colours: [.red, .green, .blue, .brown, .cyan, .darkGray, .darkText])
+            ],
+            header: "This section exhibits TableViewController's ability to remember and not re-use scroll view offsets"
+        )
     }
 }
 

--- a/ThunderTableTests/ThunderTableTests.swift
+++ b/ThunderTableTests/ThunderTableTests.swift
@@ -33,4 +33,28 @@ class ThunderTableTests: XCTestCase {
         }
     }
     
+    func testSectionIndexPathsCalculation() {
+        
+        let data = [
+            [TableRow(title: ""), TableRow(title: "")],
+            [],
+            [TableRow(title: ""), TableRow(title: ""), TableRow(title: ""), TableRow(title: "")],
+            [TableRow(title: "")]
+        ] as [Section]
+        
+        let indexPaths = data.indexPaths
+        
+        XCTAssertEqual(
+            indexPaths,
+            [
+                IndexPath(row: 0, section: 0),
+                IndexPath(row: 1, section: 0),
+                IndexPath(row: 0, section: 2),
+                IndexPath(row: 1, section: 2),
+                IndexPath(row: 2, section: 2),
+                IndexPath(row: 3, section: 2),
+                IndexPath(row: 0, section: 3)
+            ]
+        )
+    }
 }


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Adds `ScrollOffsetManager` for storing and restoring scroll offsets via a protocol implementation.

This ensures that scroll offsets are only remembered where users explicitly
request them to be, meaning we won't interfere with any custom logic they
already have to handle this.

Also adds examples of this to the demo project

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bugs were found in Blood within `ThunderCloud` where scroll offsets were incorrect due to cell re-use. This allows us to handle this better by caching scroll offsets where required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Has been tested using the demo project, and will shortly be tested within `ThunderCloud` and specifically in the case of `Blood`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
