### PR TITLE
Feature/data did set

### DIFF
--- a/ThunderTable/ScrollOffsetManagable.swift
+++ b/ThunderTable/ScrollOffsetManagable.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// A simpler version of `UIScrollViewDelegate` so we don't intefere
 /// with users `UIScrollViewDelegate` implementations
-public protocol ScrollOffsetDelegate: class {
+public protocol ScrollOffsetDelegate: AnyObject {
     
     /// Called when the content offset of the scroll view changes due to `scrollViewDidScroll`
     /// - Parameters:
@@ -20,7 +20,7 @@ public protocol ScrollOffsetDelegate: class {
 
 /// A protocol implemented to allow control and listening to scroll view offset changes
 /// by `ScrollOfffsetManager`
-public protocol ScrollOffsetManagable: class {
+public protocol ScrollOffsetManagable: AnyObject {
     
     /// The scroll view that is controllable on the object
     var scrollView: UIScrollView? { get }

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -128,7 +128,7 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
 
     /// When `true`, execute `tableView.reloadData()` on `didSet` of `data`.
     /// Only set this to `false` is changes to `tableView` should be handled by the subclass.
-    public var reloadDataOnDataDidSet = true
+    open var reloadDataOnDataDidSet = true
     
     /// The currently selected index path of the table view
 	public var selectedIndexPath: IndexPath?

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -127,7 +127,8 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
     }
 
     /// When `true`, execute `tableView.reloadData()` on `didSet` of `data`.
-    /// Only set this to `false` is changes to `tableView` should be handled by the subclass.
+    /// Subclasses which set this to `false` should handle the reloading of the `tableView` `Section`s
+    /// and `Row`s itself.
     open var reloadDataOnDataDidSet = true
     
     /// The currently selected index path of the table view

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -356,6 +356,18 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
         guard !indexPathsToReload.isEmpty else { return }
         self.tableView.reloadRows(at: indexPathsToReload, with: animation)
     }
+
+    /// Execute `closure` with `reloadDataOnDataDidSet` set to `false`.
+    /// Return `reloadDataOnDataDidSet` to it's previous value when closure returns
+    ///
+    /// - Parameter closure: Functionality to execute
+    open func withoutReloading(closure: () -> Void) {
+        let valueBefore = reloadDataOnDataDidSet
+
+        reloadDataOnDataDidSet = false
+        closure()
+        reloadDataOnDataDidSet = valueBefore
+    }
     
     private func register(row: Row) {
         

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -118,12 +118,17 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
                 resetEmbeddedScrollOffsets()
             }
             _data = newValue
+            guard reloadDataOnDataDidSet else { return }
             tableView.reloadData()
         }
         get {
             return _data
         }
     }
+
+    /// When `true`, execute `tableView.reloadData()` on `didSet` of `data`.
+    /// Only set this to `false` is changes to `tableView` should be handled by the subclass.
+    public var reloadDataOnDataDidSet = true
     
     /// The currently selected index path of the table view
 	public var selectedIndexPath: IndexPath?


### PR DESCRIPTION
When `reloadData()` is not desired after setting `data` subclasses may set `reloadDataOnDataDidSet = false`.
Subclasses should be responsible for their own reloading in this case. 

## Motivation and Context
Fix issue with a search row in an app referencing this framework.

## How Has This Been Tested?
In the app referencing this framework.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
