### PR TITLE
Create `DeclarativeSection` and override header/footer methods in `TableViewController` for when the section is `DeclarativeSection`

### DIFF
--- a/ThunderTable.xcodeproj/project.pbxproj
+++ b/ThunderTable.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		B1EC81031FDE86BF00C8EE72 /* SubtitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1EC81011FDE86BF00C8EE72 /* SubtitleTableViewCell.xib */; };
 		B1EC81061FDE873700C8EE72 /* Value1TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EC81041FDE873700C8EE72 /* Value1TableViewCell.swift */; };
 		B1EC81071FDE873700C8EE72 /* Value1TableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1EC81051FDE873700C8EE72 /* Value1TableViewCell.xib */; };
+		B8D95CF525C8729F004F32DD /* DeclarativeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -161,6 +162,7 @@
 		B1EC81011FDE86BF00C8EE72 /* SubtitleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubtitleTableViewCell.xib; sourceTree = "<group>"; };
 		B1EC81041FDE873700C8EE72 /* Value1TableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Value1TableViewCell.swift; sourceTree = "<group>"; };
 		B1EC81051FDE873700C8EE72 /* Value1TableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = Value1TableViewCell.xib; sourceTree = "<group>"; };
+		B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarativeSection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -286,6 +288,7 @@
 				B17BAA551D8963BB00844421 /* TableViewController.swift */,
 				B185A58B2398129D00B87BC7 /* TableViewController+Collection.swift */,
 				B17BAA571D89643800844421 /* TableSection.swift */,
+				B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */,
 				B17BAA591D89645000844421 /* TableRow.swift */,
 				B114F0C220359F76005D52F2 /* TableRow+Actions.swift */,
 				B11CB8CE1F320DA600E58116 /* Extensions.swift */,
@@ -564,6 +567,7 @@
 				B108319D1F068FDF008B565D /* TableImageViewCell.swift in Sources */,
 				B11264F41D8A9AE800224FB2 /* InputTableRow.swift in Sources */,
 				B114F0C320359F76005D52F2 /* TableRow+Actions.swift in Sources */,
+				B8D95CF525C8729F004F32DD /* DeclarativeSection.swift in Sources */,
 				B11CB8CF1F320DA600E58116 /* Extensions.swift in Sources */,
 				B114F10E2035CA75005D52F2 /* InputPickerRow.swift in Sources */,
 				B1EC81061FDE873700C8EE72 /* Value1TableViewCell.swift in Sources */,

--- a/ThunderTable.xcodeproj/project.pbxproj
+++ b/ThunderTable.xcodeproj/project.pbxproj
@@ -69,7 +69,7 @@
 		B1EC81031FDE86BF00C8EE72 /* SubtitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1EC81011FDE86BF00C8EE72 /* SubtitleTableViewCell.xib */; };
 		B1EC81061FDE873700C8EE72 /* Value1TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EC81041FDE873700C8EE72 /* Value1TableViewCell.swift */; };
 		B1EC81071FDE873700C8EE72 /* Value1TableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1EC81051FDE873700C8EE72 /* Value1TableViewCell.xib */; };
-		B8D95CF525C8729F004F32DD /* DeclarativeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */; };
+		B8B37A6425F1AA05002B866A /* DeclarativeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -567,7 +567,7 @@
 				B108319D1F068FDF008B565D /* TableImageViewCell.swift in Sources */,
 				B11264F41D8A9AE800224FB2 /* InputTableRow.swift in Sources */,
 				B114F0C320359F76005D52F2 /* TableRow+Actions.swift in Sources */,
-				B8D95CF525C8729F004F32DD /* DeclarativeSection.swift in Sources */,
+				B8B37A6425F1AA05002B866A /* DeclarativeSection.swift in Sources */,
 				B11CB8CF1F320DA600E58116 /* Extensions.swift in Sources */,
 				B114F10E2035CA75005D52F2 /* InputPickerRow.swift in Sources */,
 				B1EC81061FDE873700C8EE72 /* Value1TableViewCell.swift in Sources */,

--- a/ThunderTable/DeclarativeSection.swift
+++ b/ThunderTable/DeclarativeSection.swift
@@ -1,0 +1,49 @@
+//
+//  DeclarativeSection.swift
+//  ThunderTable
+//
+//  Created by Ben Shutt on 01/02/2021.
+//  Copyright © 2021 3SidedCube. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// A `TableSection` with a header and footer specified
+open class DeclarativeSection: TableSection {
+
+    /// `CGFloat` height of the header for `Section`
+    open var headerHeight: CGFloat
+
+    /// `UIView` view of the header for `Section`
+    open var headerView: UIView
+
+    /// `CGFloat` height of the footer for `Section`
+    open var footerHeight: CGFloat
+
+    /// `UIView` view of the footer for `Section`
+    open var footerView: UIView
+
+    /// Default memberwise initializer
+    ///
+    /// - Parameters:
+    ///   - rows: `[Row]`
+    ///   - headerHeight: `CGFloat`
+    ///   - headerView: `UIView`
+    ///   - footerHeight: `CGFloat`
+    ///   - footerView: `UIView`
+    public init(
+        rows: [Row],
+        headerHeight: CGFloat = 0,
+        headerView: UIView = UIView(),
+        footerHeight: CGFloat = 0,
+        footerView: UIView = UIView()
+    ) {
+        self.headerHeight = headerHeight
+        self.headerView = headerView
+        self.footerHeight = footerHeight
+        self.footerView = footerView
+
+        super.init(rows: rows)
+    }
+}

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -577,6 +577,47 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
             set(indexPath: indexPath, selected: false)
         }
     }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        heightForHeaderInSection section: Int
+    ) -> CGFloat {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, heightForHeaderInSection: section)
+        }
+        return tableSection.headerHeight
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        viewForHeaderInSection section: Int
+    ) -> UIView? {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, viewForHeaderInSection: section)
+        }
+        return tableSection.headerView
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        heightForFooterInSection section: Int
+    ) -> CGFloat {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, heightForFooterInSection: section)
+        }
+        return tableSection.footerHeight
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        viewForFooterInSection section: Int
+    ) -> UIView? {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, viewForFooterInSection: section)
+        }
+        return tableSection.footerView
+    }
+
     
     //MARK: -
     //MARK: Scroll Offset Management


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Create `DeclarativeSection` for common usage of declarative `UITableView` `Section`s

## Motivation and Context
A common use case, allows programmers to define `Section` logic in the `redraw` rather than overriding `UITableViewDelegate` methods.

## How Has This Been Tested?
Used in other company apps 

## Usage:
```swift
func redraw() {
    data = [
        DeclarativeSection(rows: [textRow]),
        DeclarativeSection(rows: answerRows, headerHeight: 16),
        DeclarativeSection(rows: answerRows, headerHeight: UITableView.automaticDimension, headerView: UILabel.header)
    ]
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
