### PR TITLE
Create `DeclarativeTableViewController` and remove `DeclarativeSection` logic from `TableViewController`

### DIFF
--- a/ThunderTable.xcodeproj/project.pbxproj
+++ b/ThunderTable.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		B1EC81031FDE86BF00C8EE72 /* SubtitleTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1EC81011FDE86BF00C8EE72 /* SubtitleTableViewCell.xib */; };
 		B1EC81061FDE873700C8EE72 /* Value1TableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1EC81041FDE873700C8EE72 /* Value1TableViewCell.swift */; };
 		B1EC81071FDE873700C8EE72 /* Value1TableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1EC81051FDE873700C8EE72 /* Value1TableViewCell.xib */; };
+		B87F86B62672208A00D58320 /* DeclarativeTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B87F86B52672208A00D58320 /* DeclarativeTableViewController.swift */; };
 		B8B37A6425F1AA05002B866A /* DeclarativeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */; };
 /* End PBXBuildFile section */
 
@@ -162,6 +163,7 @@
 		B1EC81011FDE86BF00C8EE72 /* SubtitleTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SubtitleTableViewCell.xib; sourceTree = "<group>"; };
 		B1EC81041FDE873700C8EE72 /* Value1TableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Value1TableViewCell.swift; sourceTree = "<group>"; };
 		B1EC81051FDE873700C8EE72 /* Value1TableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = Value1TableViewCell.xib; sourceTree = "<group>"; };
+		B87F86B52672208A00D58320 /* DeclarativeTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarativeTableViewController.swift; sourceTree = "<group>"; };
 		B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeclarativeSection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -286,6 +288,7 @@
 				B17BAA361D89639100844421 /* Info.plist */,
 				B1EC80FB1FDE85C000C8EE72 /* Cells */,
 				B17BAA551D8963BB00844421 /* TableViewController.swift */,
+				B87F86B52672208A00D58320 /* DeclarativeTableViewController.swift */,
 				B185A58B2398129D00B87BC7 /* TableViewController+Collection.swift */,
 				B17BAA571D89643800844421 /* TableSection.swift */,
 				B8D95CF425C8729F004F32DD /* DeclarativeSection.swift */,
@@ -576,6 +579,7 @@
 				B1EC80FE1FDE85EA00C8EE72 /* DefaultTableViewCell.swift in Sources */,
 				B1AD7EC61D8C198F00BFCA34 /* InputSwitchViewCell.swift in Sources */,
 				B1E0883D1DA638CE00E45E47 /* ImageView.swift in Sources */,
+				B87F86B62672208A00D58320 /* DeclarativeTableViewController.swift in Sources */,
 				B114F1112035CC19005D52F2 /* InputPickerViewCell.swift in Sources */,
 				B17BAA561D8963BB00844421 /* TableViewController.swift in Sources */,
 				B19C53271D8B036600B30A35 /* ApplicationLoadingIndicatorManager.swift in Sources */,

--- a/ThunderTable/DeclarativeTableViewController.swift
+++ b/ThunderTable/DeclarativeTableViewController.swift
@@ -1,0 +1,81 @@
+//
+//  DeclarativeTableViewController.swift
+//  ThunderTable
+//
+//  Created by Ben Shutt on 10/06/2021.
+//  Copyright © 2021 3SidedCube. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+/// A `TableViewController` which uses `DeclarativeSection`.
+///
+/// - Note: If we implement both
+/// - `tableView(_:titleForHeaderInSection:)` and
+/// - `tableView(_:viewForHeaderInSection:)`
+/// then `tableView(_:viewForHeaderInSection:)` takes priority (similarly for footers).
+///
+/// As `TableViewController` is already implementing `tableView(_:titleForHeaderInSection:)`
+/// it would be a breaking change to add this `DeclarativeSection` logic on there.
+/// Hence we create a new subclass.
+open class DeclarativeTableViewController: TableViewController {
+
+    // MARK: - Header
+
+    override open func tableView(
+        _ tableView: UITableView,
+        heightForHeaderInSection section: Int
+    ) -> CGFloat {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, heightForHeaderInSection: section)
+        }
+        return tableSection.headerHeight
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        viewForHeaderInSection section: Int
+    ) -> UIView? {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, viewForHeaderInSection: section)
+        }
+        return tableSection.headerView
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        titleForHeaderInSection section: Int
+    ) -> String? {
+        return nil
+    }
+
+    // MARK: - Footer
+
+    override open func tableView(
+        _ tableView: UITableView,
+        heightForFooterInSection section: Int
+    ) -> CGFloat {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, heightForFooterInSection: section)
+        }
+        return tableSection.footerHeight
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        viewForFooterInSection section: Int
+    ) -> UIView? {
+        guard let tableSection = data[section] as? DeclarativeSection else {
+            return super.tableView(tableView, viewForFooterInSection: section)
+        }
+        return tableSection.footerView
+    }
+
+    override open func tableView(
+        _ tableView: UITableView,
+        titleForFooterInSection section: Int
+    ) -> String? {
+        return nil
+    }
+}

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -577,47 +577,6 @@ open class TableViewController: UITableViewController, UIContentSizeCategoryAdju
             set(indexPath: indexPath, selected: false)
         }
     }
-
-    override open func tableView(
-        _ tableView: UITableView,
-        heightForHeaderInSection section: Int
-    ) -> CGFloat {
-        guard let tableSection = data[section] as? DeclarativeSection else {
-            return super.tableView(tableView, heightForHeaderInSection: section)
-        }
-        return tableSection.headerHeight
-    }
-
-    override open func tableView(
-        _ tableView: UITableView,
-        viewForHeaderInSection section: Int
-    ) -> UIView? {
-        guard let tableSection = data[section] as? DeclarativeSection else {
-            return super.tableView(tableView, viewForHeaderInSection: section)
-        }
-        return tableSection.headerView
-    }
-
-    override open func tableView(
-        _ tableView: UITableView,
-        heightForFooterInSection section: Int
-    ) -> CGFloat {
-        guard let tableSection = data[section] as? DeclarativeSection else {
-            return super.tableView(tableView, heightForFooterInSection: section)
-        }
-        return tableSection.footerHeight
-    }
-
-    override open func tableView(
-        _ tableView: UITableView,
-        viewForFooterInSection section: Int
-    ) -> UIView? {
-        guard let tableSection = data[section] as? DeclarativeSection else {
-            return super.tableView(tableView, viewForFooterInSection: section)
-        }
-        return tableSection.footerView
-    }
-
     
     //MARK: -
     //MARK: Scroll Offset Management


### PR DESCRIPTION
## Description
Fix issue with implementing both:
```swift
tableView(_:titleForHeaderInSection:)
tableView(_:viewForHeaderInSection:)
```

Use of `DeclarativeSection` will now require use of `DeclarativeTableViewController`
Note - this was actually never merged, this is a fix into a release branch.

## Motivation and Context
Fixing previous change

## How Has This Been Tested?
Referencing apps

## Screenshots (if appropriate):
![Simulator Screen Shot - iPhone 12 - 2021-06-10 at 11 38 38](https://user-images.githubusercontent.com/57952587/121511395-7ce26080-c9e0-11eb-931f-f4a3b34bae4c.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
