### PR TITLE
Fixes crash accessing IndexPath's section

### DIFF
--- a/ThunderTable.xcodeproj/project.pbxproj
+++ b/ThunderTable.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		B14F945B20444E820014F694 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B14F945920444E820014F694 /* LaunchScreen.storyboard */; };
 		B14F946020444E910014F694 /* ThunderTable.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B17BAA321D89639100844421 /* ThunderTable.framework */; };
 		B14F946120444E910014F694 /* ThunderTable.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B17BAA321D89639100844421 /* ThunderTable.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B1689E6827C3F26500A53ACC /* IndexPath+SafeSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1689E6727C3F26500A53ACC /* IndexPath+SafeSection.swift */; };
 		B1784D831D8C3A60007358EA /* InputSliderRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1784D821D8C3A60007358EA /* InputSliderRow.swift */; };
 		B1784D861D8C3A8A007358EA /* InputSliderViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1784D841D8C3A8A007358EA /* InputSliderViewCell.swift */; };
 		B1784D871D8C3A8A007358EA /* InputSliderViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B1784D851D8C3A8A007358EA /* InputSliderViewCell.xib */; };
@@ -115,6 +116,7 @@
 		B14F945720444E820014F694 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B14F945A20444E820014F694 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B14F945C20444E820014F694 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B1689E6727C3F26500A53ACC /* IndexPath+SafeSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IndexPath+SafeSection.swift"; sourceTree = "<group>"; };
 		B1784D821D8C3A60007358EA /* InputSliderRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSliderRow.swift; sourceTree = "<group>"; };
 		B1784D841D8C3A8A007358EA /* InputSliderViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InputSliderViewCell.swift; sourceTree = "<group>"; };
 		B1784D851D8C3A8A007358EA /* InputSliderViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = InputSliderViewCell.xib; sourceTree = "<group>"; };
@@ -234,6 +236,7 @@
 		B12D31062512347800274462 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				B1689E6727C3F26500A53ACC /* IndexPath+SafeSection.swift */,
 			);
 			name = Extensions;
 			sourceTree = "<group>";
@@ -574,6 +577,7 @@
 				B19C53241D8B033E00B30A35 /* InputTextFieldViewCell.swift in Sources */,
 				B1B5C6D624FFCAAD00F05CE8 /* ScrollOffsetManager.swift in Sources */,
 				B1EC80FE1FDE85EA00C8EE72 /* DefaultTableViewCell.swift in Sources */,
+				B1689E6827C3F26500A53ACC /* IndexPath+SafeSection.swift in Sources */,
 				B1AD7EC61D8C198F00BFCA34 /* InputSwitchViewCell.swift in Sources */,
 				B1E0883D1DA638CE00E45E47 /* ImageView.swift in Sources */,
 				B114F1112035CC19005D52F2 /* InputPickerViewCell.swift in Sources */,

--- a/ThunderTable/IndexPath+SafeSection.swift
+++ b/ThunderTable/IndexPath+SafeSection.swift
@@ -1,0 +1,20 @@
+//
+//  IndexPath+SafeSection.swift
+//  ThunderTable
+//
+//  Created by Simon Mitchell on 21/02/2022.
+//  Copyright © 2022 3SidedCube. All rights reserved.
+//
+
+import Foundation
+
+extension IndexPath {
+
+    /// This provides safe access to `self.section` as with VoiceOver on sometimes an `IndexPath`
+    /// is passed to methods which has an empty array of `indexes` and causes a "trap" in the internals of `IndexPath`
+    /// - Note: See discussion here: https://developer.apple.com/forums/thread/663787
+    var safeSection: Int? {
+        guard count == 2 else { return nil }
+        return section
+    }
+}

--- a/ThunderTable/TableViewController+Collection.swift
+++ b/ThunderTable/TableViewController+Collection.swift
@@ -13,12 +13,12 @@ extension TableViewController {
     //MARK: - Subscript Functions
     
     public subscript (index: IndexPath) -> (section: Section, row: Row)? {
-        
-        guard index.section < data.count else {
+
+        guard let safeSectionIndex = index.safeSection, safeSectionIndex < data.count else {
             return nil
         }
         
-        let section = data[index.section]
+        let section = data[safeSectionIndex]
         guard index.row < section.rows.count else {
             return nil
         }
@@ -32,11 +32,11 @@ extension TableViewController {
     
     public subscript (section index: IndexPath) -> Section? {
         
-        guard index.section < data.count else {
+        guard let safeSectionIndex = index.safeSection, safeSectionIndex < data.count else {
             return nil
         }
         
-        return data[index.section]
+        return data[safeSectionIndex]
     }
     
     /// forEach Array equivalant for looping across all sections and rows of current `data`

--- a/ThunderTable/TableViewController.swift
+++ b/ThunderTable/TableViewController.swift
@@ -755,19 +755,20 @@ public extension TableViewController {
     func moveToInputCell(after indexPath: IndexPath) {
         
         outerLoop: for (sectionIndex, section) in data.enumerated() {
-            
-            if sectionIndex >= indexPath.section {
-                
-                for (rowIndex, row) in section.rows.enumerated() {
-                    
-                    if row is InputRow, rowIndex > indexPath.row {
-                        
-                        let indexPath = IndexPath(row: rowIndex, section: sectionIndex)
-                        tableView.scrollToRow(at: indexPath, at: .top, animated: true)
-                        set(indexPath: indexPath, selected: true)
-                        
-                        break outerLoop
-                    }
+
+            guard let indexPathSection = indexPath.safeSection, sectionIndex >= indexPathSection else {
+                continue
+            }
+
+            for (rowIndex, row) in section.rows.enumerated() {
+
+                if row is InputRow, rowIndex > indexPath.row {
+
+                    let indexPath = IndexPath(row: rowIndex, section: sectionIndex)
+                    tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+                    set(indexPath: indexPath, selected: true)
+
+                    break outerLoop
                 }
             }
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes crash caused when we are sent an IndexPath with 0 elements in it's `indexes` array (occasionally when VoiceOver enabled). See: https://developer.apple.com/forums/thread/663787

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a crash in (potentially) all of our apps when VoiceOver enabled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally in ARC Emergency

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
