### PR TITLE
🔴 High: Add availability check for yearAndMonth [XS]

### DIFF
--- a/ThunderTable/InputDatePickerRow.swift
+++ b/ThunderTable/InputDatePickerRow.swift
@@ -125,9 +125,11 @@ open class InputDatePickerRow: InputTableRow {
 		case .countDownTimer:
 			dateFormatter.dateFormat = "'Every' HH 'hours' mm 'minutes'"
 			break
+        #if swift(>=5.10)
         case .yearAndMonth:
             dateFormatter.dateFormat = "MM/yyyy"
             break
+        #endif
         @unknown default:
             fatalError("Unknown `UIDatePicker.Mode` encountered in `InputDatePickerRow` please add support for this new enum value")
         }


### PR DESCRIPTION
**What?**
Add compile time check for Swift 5.10 on `UIDatePicker.Mode.yearAndMonth`.

**Why?**
Versions of Xcode prior to 15.4 cannot compile ThunderTable as it stands.